### PR TITLE
Add Redux store with RTK Query integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@ Este proyecto es la interfaz de usuario del sistema de gestión de riesgos labor
 - 🎨 Tailwind CSS
 - 🧠 React Hooks personalizados
 - 🔐 JWT Login (con consumo de backend Django)
-- 📦 axios para consumir API REST
+- 📦 axios para consumir API REST (legacy)
+- 🗃️ Redux Toolkit y RTK Query para el nuevo manejo de estado global
 
 ---
 
-## 📁 Estructura del proyecto
+## 📦 Manejo de estado
 
+El proyecto ahora incluye un store global basado en **Redux Toolkit**. Los datos
+como `empresaId` y la autenticación se almacenan en slices dentro de `src/store`.
+Además, las peticiones a la API se gestionan a través de **RTK Query** en
+`apiSlice.js`.
+
+## 📁 Estructura del proyecto

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "2.0.18",
         "@material-tailwind/react": "^2.1.4",
+        "@reduxjs/toolkit": "^2.8.2",
         "@shadcn/ui": "^0.0.4",
         "@tanstack/react-query": "^5.80.2",
         "@tanstack/react-query-devtools": "^5.80.2",
@@ -25,6 +26,7 @@
         "react-apexcharts": "1.4.1",
         "react-dom": "18.2.0",
         "react-i18next": "^15.4.1",
+        "react-redux": "^9.2.0",
         "react-router-dom": "6.17.0"
       },
       "devDependencies": {
@@ -1008,6 +1010,32 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
@@ -1062,6 +1090,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.80.2",
@@ -1165,14 +1205,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.31.tgz",
       "integrity": "sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1194,7 +1234,13 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1714,7 +1760,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -2425,6 +2471,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -3450,6 +3506,29 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -3529,10 +3608,31 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -4162,6 +4262,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/react": "2.0.18",
     "@material-tailwind/react": "^2.1.4",
+    "@reduxjs/toolkit": "^2.8.2",
     "@shadcn/ui": "^0.0.4",
     "@tanstack/react-query": "^5.80.2",
     "@tanstack/react-query-devtools": "^5.80.2",
@@ -26,6 +27,7 @@
     "react-apexcharts": "1.4.1",
     "react-dom": "18.2.0",
     "react-i18next": "^15.4.1",
+    "react-redux": "^9.2.0",
     "react-router-dom": "6.17.0"
   },
   "devDependencies": {

--- a/src/hooks/useEmployees.js
+++ b/src/hooks/useEmployees.js
@@ -1,14 +1,5 @@
-// src/hooks/useEmployees.js
-import { useQuery } from "@tanstack/react-query";
-import api from "@/services/api";
+import { useGetEmployeesQuery } from '@/store/apiSlice';
 
 export function useEmployees() {
-  return useQuery({
-    queryKey: ["employees"],
-    queryFn: async () => {
-      const res = await api.get("/employees/");
-      const payload = res.data;
-      return Array.isArray(payload) ? payload : payload.results || [];
-    },
-  });
+  return useGetEmployeesQuery();
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,32 +1,36 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
 import './i18n';
-import { BrowserRouter } from "react-router-dom";
-import { ThemeProvider } from "@material-tailwind/react";
-import { MaterialTailwindControllerProvider } from "@/context";
-import "../public/css/tailwind.css";
-import { EmpresaProvider } from "@/context/EmpresaContext.jsx";
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '@material-tailwind/react';
+import { MaterialTailwindControllerProvider } from '@/context';
+import '../public/css/tailwind.css';
+import { EmpresaProvider } from '@/context/EmpresaContext.jsx';
+import { Provider } from 'react-redux';
+import { store } from '@/store';
 
 // React Query
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient();
 
-ReactDOM.createRoot(document.getElementById("root")).render(
+ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <EmpresaProvider>
-        <BrowserRouter>
-          <ThemeProvider>
-            <MaterialTailwindControllerProvider>
-              <App />
-              <ReactQueryDevtools initialIsOpen={false} />
-            </MaterialTailwindControllerProvider>
-          </ThemeProvider>
-        </BrowserRouter>
-      </EmpresaProvider>
-    </QueryClientProvider>
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <EmpresaProvider>
+          <BrowserRouter>
+            <ThemeProvider>
+              <MaterialTailwindControllerProvider>
+                <App />
+                <ReactQueryDevtools initialIsOpen={false} />
+              </MaterialTailwindControllerProvider>
+            </ThemeProvider>
+          </BrowserRouter>
+        </EmpresaProvider>
+      </QueryClientProvider>
+    </Provider>
   </React.StrictMode>
 );

--- a/src/store/apiSlice.js
+++ b/src/store/apiSlice.js
@@ -1,0 +1,41 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const baseQuery = fetchBaseQuery({
+  baseUrl: 'http://localhost:8000/api/',
+  prepareHeaders: headers => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      headers.set('Authorization', `Token ${token}`);
+    }
+    const empresaId = localStorage.getItem('empresaActivaId');
+    if (empresaId) {
+      headers.set('X-Active-Company', empresaId);
+    }
+    return headers;
+  }
+});
+
+const baseQueryWithAuth = async (args, api, extraOptions) => {
+  const result = await baseQuery(args, api, extraOptions);
+  if (result.error && result.error.status === 401) {
+    localStorage.removeItem('token');
+    localStorage.removeItem('empresaActivaId');
+    localStorage.removeItem('user');
+    window.location.href = '/?expired=1';
+  }
+  return result;
+};
+
+export const apiSlice = createApi({
+  reducerPath: 'api',
+  baseQuery: baseQueryWithAuth,
+  endpoints: builder => ({
+    getEmployees: builder.query({
+      query: () => 'employees/',
+      transformResponse: response => (Array.isArray(response) ? response : response.results || [])
+    })
+    // Add additional endpoints here
+  })
+});
+
+export const { useGetEmployeesQuery } = apiSlice;

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -1,0 +1,40 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const storedUser = localStorage.getItem('user');
+
+const initialState = {
+  token: localStorage.getItem('token') || null,
+  user: storedUser ? JSON.parse(storedUser) : null
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setCredentials(state, action) {
+      const { token, user } = action.payload;
+      state.token = token;
+      state.user = user;
+      if (token) {
+        localStorage.setItem('token', token);
+      } else {
+        localStorage.removeItem('token');
+      }
+      if (user) {
+        localStorage.setItem('user', JSON.stringify(user));
+      } else {
+        localStorage.removeItem('user');
+      }
+    },
+    logOut(state) {
+      state.token = null;
+      state.user = null;
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      localStorage.removeItem('empresaActivaId');
+    }
+  }
+});
+
+export const { setCredentials, logOut } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/empresaSlice.js
+++ b/src/store/empresaSlice.js
@@ -1,0 +1,29 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  id: null
+};
+
+const empresaSlice = createSlice({
+  name: 'empresa',
+  initialState,
+  reducers: {
+    setEmpresaId(state, action) {
+      state.id = action.payload;
+      if (state.id !== null && state.id !== undefined) {
+        localStorage.setItem('empresaActivaId', state.id);
+      } else {
+        localStorage.removeItem('empresaActivaId');
+      }
+    },
+    initEmpresaId(state) {
+      const stored = localStorage.getItem('empresaActivaId');
+      if (stored) {
+        state.id = Number(stored);
+      }
+    }
+  }
+});
+
+export const { setEmpresaId, initEmpresaId } = empresaSlice.actions;
+export default empresaSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+import empresaReducer from './empresaSlice';
+import authReducer from './authSlice';
+import { apiSlice } from './apiSlice';
+
+export const store = configureStore({
+  reducer: {
+    empresa: empresaReducer,
+    auth: authReducer,
+    [apiSlice.reducerPath]: apiSlice.reducer
+  },
+  middleware: getDefaultMiddleware => getDefaultMiddleware().concat(apiSlice.middleware)
+});


### PR DESCRIPTION
## Summary
- install `@reduxjs/toolkit` and `react-redux`
- implement slices for auth and empresaId
- create RTK Query `apiSlice` and store setup
- update `useEmployees` hook to use the new API slice
- wrap application with Redux `Provider`
- document the new state management approach

## Testing
- `npm run build` *(fails: Could not load /src/pages/dashboard/Profile.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_688c1605ef7c83309ccd73a86bc37081